### PR TITLE
Tighten lower bound on base to fix bad install plan on GHC 7.8

### DIFF
--- a/pptable.cabal
+++ b/pptable.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:     src
   exposed-modules:    Text.PrettyPrint.Tabulate
-  build-depends:      base >= 4.7 && < 5
+  build-depends:      base >= 4.8 && < 5
                      , syb
                      , containers
                      , pretty


### PR DESCRIPTION
pptable 0.3.0.0 had a bad build plan on GHC 7.8 I noticed here https://matrix.hackage.haskell.org/package/pptable

In my capacity as a Hackage Trustee, I've made a [metadata revision](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md) to fix this on 0.3.0.0, so there's no need to make a new release, but please merge this pull request so that future releases are not affected.

I've also revised 0.1.0.0 which did not build on GHC 8 or above, due to the fixing of (this bug)[https://ghc.haskell.org/trac/ghc/ticket/7854]